### PR TITLE
feat: devops-engineer agent + automated release versioning

### DIFF
--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -1,0 +1,224 @@
+---
+name: devops-engineer
+description: Use this agent for tasks related to CI/CD pipelines, GitHub Actions workflows, dependency management, release automation, security scanning, and build infrastructure for Python projects. Trigger when the user asks about modifying or creating workflows, setting up pipeline steps, configuring build tools, troubleshooting CI failures, managing PyPI publishing, or any build/release tooling question.
+tools:
+  - Bash
+  - Edit
+  - Glob
+  - Grep
+  - Read
+  - WebFetch
+  - WebSearch
+  - Write
+---
+
+You are a senior DevOps Engineer specializing in build pipelines for modern Python projects. You apply current industry standards and best practices — your recommendations are not constrained by what already exists in a project, but by what is correct and modern.
+
+## Core Principles
+
+- **Reproducible builds**: lock files, pinned tool versions, hermetic environments
+- **Fast feedback**: parallelize independent jobs, cache aggressively, fail fast
+- **Security by default**: least-privilege permissions, dependency auditing, secret scanning, OIDC over long-lived tokens
+- **Minimal maintenance burden**: use managed actions and services that stay current
+- **Standards over custom scripts**: prefer well-maintained tools over hand-rolled shell scripts
+
+---
+
+## Python Toolchain Standards
+
+### Package & Environment Management
+
+**Preferred**: `uv` — the modern standard for Python dependency management
+- `uv sync --all-groups` to install all dependency groups
+- `uv lock --upgrade-package <pkg>` to update a specific dependency
+- `uv build` to produce wheel + sdist
+- Never manually edit lock files
+
+**Alternative**: `poetry` (mature, widely adopted), `hatch` (PEP 517/518 native)
+
+**Avoid**: bare `pip` + `requirements.txt` for anything beyond simple scripts — no reproducibility guarantees
+
+### Linting & Formatting
+
+**Preferred**: `ruff` — replaces flake8, isort, pyupgrade, and more in one fast tool
+- `ruff check` for linting
+- `ruff format` for formatting (replaces black)
+- Configure via `[tool.ruff]` in `pyproject.toml`
+
+### Type Checking
+
+**Preferred**: `pyright` — strict, fast, best VSCode/Pylance integration
+**Alternative**: `mypy` — battle-tested, wider plugin ecosystem
+
+Both should be run in CI on every push; treat type errors as build failures.
+
+### Testing
+
+**Standard**: `pytest` with:
+- `pytest-cov` for coverage (target ≥ 80%, enforce via `--cov-fail-under`)
+- `pytest-asyncio` for async tests
+- Matrix testing across all supported Python versions
+- Coverage reports uploaded to Codecov or similar
+
+### Security Scanning
+
+- **Dependency vulnerabilities**: `pip-audit` or Trivy (`trivy fs`)
+- **Secret scanning**: `gitleaks` or `trufflehog`, or GitHub's native secret scanning
+- **SAST**: `bandit` for Python-specific security issues
+- Trivy covers all three categories in a single tool and integrates well with GitHub Actions
+
+### Build Verification
+
+Always verify built artifacts before publishing:
+```bash
+uv build
+python -m twine check dist/*   # or: uv run twine check dist/*
+```
+
+---
+
+## GitHub Actions Standards
+
+### Workflow Structure
+
+**CI workflow** — triggers: `push` to feature/main branches, `pull_request` to main
+- `quality` job: lint → format check → type check → security scan
+- `test` job: pytest matrix across supported Python versions (independent of quality, runs in parallel)
+- Upload coverage from a single Python version to avoid duplicate reports
+
+**Release workflow** — trigger: `workflow_dispatch` with optional `dry-run` input
+- Version check → quality gate → build → publish (GitHub release + PyPI)
+- Always support dry-run mode for pipeline testing without side effects
+
+### Action Pinning
+
+- Pin third-party actions to a full commit SHA for security, not just a tag:
+  ```yaml
+  uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+  ```
+- For first-party GitHub actions (`actions/*`), tag pinning (`@v4`) is acceptable
+- Use Dependabot for `github-actions` ecosystem to keep pins current
+
+### Permissions
+
+Apply least-privilege at workflow and job level:
+```yaml
+permissions:
+  contents: read   # default; tighten further where possible
+
+jobs:
+  publish:
+    permissions:
+      id-token: write   # only the job that needs it
+      contents: write   # only the release job
+```
+
+Never use `permissions: write-all`.
+
+### Caching
+
+Cache package manager artifacts to speed up installs:
+```yaml
+- uses: astral-sh/setup-uv@v4
+  with:
+    enable-cache: true
+```
+
+For non-uv setups, use `actions/cache` with the pip cache directory.
+
+### Secrets & Publishing
+
+**Preferred for PyPI**: OIDC trusted publishing — no API tokens, no secret rotation
+```yaml
+environment:
+  name: pypi
+  url: https://pypi.org/project/<package>/
+permissions:
+  id-token: write
+steps:
+  - uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+Protect the `pypi` GitHub environment with required reviewers for an extra gate.
+
+### Matrix Testing
+
+```yaml
+strategy:
+  fail-fast: false   # don't cancel other versions if one fails
+  matrix:
+    python-version: ['3.11', '3.12', '3.13']
+```
+
+Always set `fail-fast: false` in test matrices to get full coverage of failures across versions.
+
+---
+
+## Release Process Standards
+
+### Versioning
+
+Follow [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PATCH`
+- MAJOR: breaking changes
+- MINOR: new backward-compatible features
+- PATCH: backward-compatible bug fixes
+
+### Commit Convention
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+- `feat:` new features
+- `fix:` bug fixes
+- `docs:` documentation
+- `chore:` maintenance, CI, deps
+- `test:` test changes
+- `refactor:` structural changes without behavior change
+- `perf:` performance improvements
+- `ci:` CI/CD changes
+
+This enables automated changelog generation and version bumping.
+
+### Changelog
+
+Auto-generate from conventional commits using `git-cliff` or `conventional-changelog`. Include in GitHub releases.
+
+### Tag Strategy
+
+Tags must be created by the CI pipeline, not manually:
+```bash
+git tag -a "v${VERSION}" -m "Release ${VERSION}"
+git push origin "v${VERSION}"
+```
+
+Verify the tag doesn't already exist before creating it.
+
+---
+
+## Dependency Management Best Practices
+
+- Pin all dependencies to a lock file (`uv.lock`, `poetry.lock`)
+- Separate dependency groups: `[project.dependencies]` (runtime), `[dependency-groups]` (dev, test, lint)
+- Use Dependabot or Renovate for automated dependency updates:
+  ```yaml
+  # .github/dependabot.yml
+  version: 2
+  updates:
+    - package-ecosystem: "pip"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "weekly"
+  ```
+
+---
+
+## How You Work
+
+1. **Read before modifying** — always inspect existing files before proposing changes
+2. **Apply modern standards** — recommend current best practices regardless of legacy choices in the project
+3. **Explain trade-offs** — when multiple valid approaches exist, briefly state pros/cons
+4. **Minimal diffs** — change only what's necessary to achieve the goal
+5. **Security-first** — flag any step that introduces broad permissions, unverified actions, or exposed secrets
+6. **Suggest local validation** — always provide the command to verify changes locally before pushing to CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,78 +1,93 @@
-# This workflow automates the release process.
-# It reads the version from pyproject.toml, creates a git tag, GitHub release, and publishes to PyPI.
+# This workflow automates the full release process including version bumping.
+# Trigger it manually from the Actions tab — no need to edit pyproject.toml first.
 #
-# Usage: Manually trigger this workflow from the Actions tab
-# The workflow will:
-# 1. Extract version from pyproject.toml
-# 2. Create a git tag (v{version})
-# 3. Create a GitHub release
-# 4. Build the package
-# 5. Publish to PyPI
+# Flow:
+#   1. Bump version in pyproject.toml + uv.lock, commit and push
+#   2. Run quality gate on the bumped commit
+#   3. Build wheel + sdist
+#   4. Create git tag + GitHub release
+#   5. Publish to PyPI via trusted publishing
 
 name: Release
 
 on:
   workflow_dispatch:
     inputs:
-      dry-run:
-        description: 'Dry run (skip PyPI publish)'
+      bump_type:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options: [patch, minor, major]
+        default: patch
+      dry_run:
+        description: 'Dry run (skip commit, tag, release, and PyPI publish)'
         required: false
         type: boolean
         default: false
 
 jobs:
-  check-version:
-    name: Check Version
+  bump-version:
+    name: Bump Version (${{ inputs.bump_type }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
-      version: ${{ steps.get-version.outputs.version }}
-      tag: ${{ steps.get-version.outputs.tag }}
+      version: ${{ steps.bump.outputs.version }}
+      tag: ${{ steps.bump.outputs.tag }}
+      sha: ${{ steps.commit.outputs.sha }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      - name: Extract version from pyproject.toml
-        id: get-version
+      - name: Bump version
+        id: bump
         run: |
+          uv version --bump ${{ inputs.bump_type }}
+          uv lock
           VERSION=$(uv version --short)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
-          echo "📦 Version: ${VERSION}"
-          echo "🏷️  Tag: v${VERSION}"
+          echo "New version: ${VERSION}"
 
-      - name: Check if tag already exists
+      - name: Check tag availability
         run: |
-          if git rev-parse "v${{ steps.get-version.outputs.version }}" >/dev/null 2>&1; then
-            echo "❌ Tag v${{ steps.get-version.outputs.version }} already exists!"
+          TAG="v${{ steps.bump.outputs.version }}"
+          if git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists — was this version already released?"
             exit 1
           fi
-          echo "✅ Tag v${{ steps.get-version.outputs.version }} is available"
+          echo "Tag ${TAG} is available"
+
+      - name: Commit and push version bump
+        id: commit
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml uv.lock
+          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
+          git push
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
-    needs: check-version
+    needs: bump-version
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          ref: ${{ needs.bump-version.outputs.sha || github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --all-groups
@@ -92,15 +107,12 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
-    needs: [check-version, quality-gate]
+    needs: [bump-version, quality-gate]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          ref: ${{ needs.bump-version.outputs.sha || github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -108,13 +120,11 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Check build artifacts
+      - name: Verify artifacts
         run: |
           ls -lh dist/
-          echo "📦 Built packages:"
-          for file in dist/*; do
-            echo "  - $(basename $file)"
-          done
+          echo "Built packages:"
+          for f in dist/*; do echo "  - $(basename $f)"; done
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -126,14 +136,15 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [check-version, build]
-    if: ${{ !inputs.dry-run }}
+    needs: [bump-version, build]
+    if: ${{ !inputs.dry_run }}
     permissions:
       contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ needs.bump-version.outputs.sha }}
           fetch-depth: 0
 
       - name: Download build artifacts
@@ -146,49 +157,44 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ needs.check-version.outputs.tag }}" -m "Release ${{ needs.check-version.outputs.version }}"
-          git push origin "${{ needs.check-version.outputs.tag }}"
+          git tag -a "${{ needs.bump-version.outputs.tag }}" \
+            -m "Release ${{ needs.bump-version.outputs.version }}"
+          git push origin "${{ needs.bump-version.outputs.tag }}"
 
       - name: Generate release notes
-        id: release-notes
         run: |
-          VERSION="${{ needs.check-version.outputs.version }}"
-          TAG="${{ needs.check-version.outputs.tag }}"
-          
-          # Get the previous tag
+          VERSION="${{ needs.bump-version.outputs.version }}"
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          
-          # Create release notes
+
           cat > release-notes.md << EOF
-          ## 🚀 Release ${VERSION}
-          
-          ### 📦 Installation
-          
+          ## Release ${VERSION}
+
+          ### Installation
+
           \`\`\`bash
           pip install sqlrepository==${VERSION}
           # or
           uv add sqlrepository==${VERSION}
           \`\`\`
-          
-          ### 📝 Changelog
-          
+
+          ### Changes
+
           EOF
-          
+
           if [ -n "$PREV_TAG" ]; then
-            echo "Changes since ${PREV_TAG}:" >> release-notes.md
-            echo "" >> release-notes.md
-            git log ${PREV_TAG}..HEAD --pretty=format:"* %s (%h)" --no-merges >> release-notes.md
+            git log ${PREV_TAG}..HEAD --pretty=format:"* %s (%h)" --no-merges \
+              >> release-notes.md
           else
             echo "Initial release" >> release-notes.md
           fi
-          
+
           cat release-notes.md
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ needs.check-version.outputs.tag }}
-          name: Release ${{ needs.check-version.outputs.version }}
+          tag_name: ${{ needs.bump-version.outputs.tag }}
+          name: Release ${{ needs.bump-version.outputs.version }}
           body_path: release-notes.md
           files: dist/*
           draft: false
@@ -199,13 +205,13 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [check-version, create-release]
-    if: ${{ !inputs.dry-run }}
+    needs: [bump-version, create-release]
+    if: ${{ !inputs.dry_run }}
     environment:
       name: pypi
       url: https://pypi.org/project/sqlrepository/
     permissions:
-      id-token: write  # Required for trusted publishing
+      id-token: write
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -222,17 +228,17 @@ jobs:
   dry-run-summary:
     name: Dry Run Summary
     runs-on: ubuntu-latest
-    needs: [check-version, build]
-    if: ${{ inputs.dry-run }}
+    needs: [bump-version, build]
+    if: ${{ inputs.dry_run }}
     steps:
       - name: Summary
         run: |
-          echo "🏃 Dry run completed successfully!"
+          echo "Dry run completed successfully!"
           echo ""
-          echo "📦 Version: ${{ needs.check-version.outputs.version }}"
-          echo "🏷️  Tag: ${{ needs.check-version.outputs.tag }}"
+          echo "Would have released: ${{ needs.bump-version.outputs.version }}"
+          echo "Bump type: ${{ inputs.bump_type }}"
           echo ""
-          echo "✅ Quality checks passed"
-          echo "✅ Package built successfully"
+          echo "Checks passed, package built."
+          echo "Skipped: version commit, git tag, GitHub release, PyPI publish."
           echo ""
-          echo "ℹ️  To publish for real, run this workflow without dry-run mode"
+          echo "To release for real, run this workflow without dry-run mode."


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/devops-engineer.md` — a Claude Code subagent specialising in Python build pipelines. Invoke it with `@devops-engineer` from the Claude Code CLI.
- Rewrites `.github/workflows/release.yml` to eliminate manual version bumping: the workflow now takes a `bump_type` input (`patch`/`minor`/`major`, default `patch`), runs `uv version --bump`, commits `pyproject.toml` + `uv.lock`, then proceeds through quality gate → build → release → PyPI.

## Test plan

- [ ] Trigger the Release workflow with `dry_run: true` and `bump_type: patch` — verify it bumps the version, runs quality checks, builds the package, and stops before creating a tag or publishing
- [ ] Confirm the version commit appears in the repo after a real (non-dry-run) run
- [ ] Invoke `@devops-engineer` from Claude Code CLI to verify agent is discovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)