### PR TITLE
fix: correct SHA pin for peter-evans/create-pull-request

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -26,7 +26,7 @@ jobs:
         run: uv lock --upgrade
 
       - name: Open pull request if lock file changed
-        uses: peter-evans/create-pull-request@67ccf781d68cd99a0716f4b0c98abb00e9c3b8a0  # v7.0.6
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f  # v7.0.6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/update-deps


### PR DESCRIPTION
The previous SHA was hallucinated. Replaced with the real SHA for v7.0.6 verified via the GitHub API.