### PR TITLE
chore: modernize and harden CI/CD pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,91 +1,42 @@
-# This workflow automates the full release process including version bumping.
-# Trigger it manually from the Actions tab — no need to edit pyproject.toml first.
+# This workflow automates the release process when a version tag is pushed.
 #
 # Flow:
-#   1. Bump version in pyproject.toml + uv.lock, commit and push
-#   2. Run quality gate on the bumped commit
+#   1. Developer bumps version locally and pushes a vX.Y.Z tag
+#   2. Quality gate runs on the tagged commit
 #   3. Build wheel + sdist
-#   4. Create git tag + GitHub release
+#   4. Create GitHub release with git-cliff release notes
 #   5. Publish to PyPI via trusted publishing
+#
+# Release steps:
+#   uv version --bump patch|minor|major
+#   git add pyproject.toml uv.lock
+#   git commit -m "chore: bump version to X.Y.Z"
+#   git tag vX.Y.Z
+#   git push origin main vX.Y.Z
 
 name: Release
 
 on:
+  push:
+    tags: ['v*']
   workflow_dispatch:
     inputs:
-      bump_type:
-        description: 'Version bump type'
-        required: true
-        type: choice
-        options: [patch, minor, major]
-        default: patch
       dry_run:
-        description: 'Dry run (skip commit, tag, release, and PyPI publish)'
+        description: 'Dry run (skip release and PyPI publish)'
         required: false
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read
 
 jobs:
-  bump-version:
-    name: Bump Version (${{ inputs.bump_type }})
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      version: ${{ steps.bump.outputs.version }}
-      tag: ${{ steps.bump.outputs.tag }}
-      sha: ${{ steps.commit.outputs.sha }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          fetch-depth: 0
-
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-
-      - name: Bump version
-        id: bump
-        run: |
-          uv version --bump ${{ inputs.bump_type }}
-          uv lock
-          VERSION=$(uv version --short)
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
-          echo "New version: ${VERSION}"
-
-      - name: Check tag availability
-        run: |
-          TAG="v${{ steps.bump.outputs.version }}"
-          if git rev-parse "${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists — was this version already released?"
-            exit 1
-          fi
-          echo "Tag ${TAG} is available"
-
-      - name: Commit and push version bump
-        id: commit
-        if: ${{ !inputs.dry_run }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml uv.lock
-          git commit -m "chore: bump version to ${{ steps.bump.outputs.version }}"
-          git push
-          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
-    needs: bump-version
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ needs.bump-version.outputs.sha || github.sha }}
 
       - name: Set up environment
         uses: ./.github/actions/setup-env
@@ -105,12 +56,10 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
-    needs: [bump-version, quality-gate]
+    needs: quality-gate
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ needs.bump-version.outputs.sha || github.sha }}
 
       - name: Set up environment
         uses: ./.github/actions/setup-env
@@ -137,15 +86,14 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [bump-version, build]
-    if: ${{ !inputs.dry_run }}
+    needs: build
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     permissions:
       contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          ref: ${{ needs.bump-version.outputs.sha }}
           fetch-depth: 0
 
       - name: Set up environment
@@ -157,13 +105,13 @@ jobs:
           name: dist
           path: dist/
 
-      - name: Create git tag
+      - name: Extract version from tag
+        id: version
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ needs.bump-version.outputs.tag }}" \
-            -m "Release ${{ needs.bump-version.outputs.version }}"
-          git push origin "${{ needs.bump-version.outputs.tag }}"
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Generate release notes
         run: |
@@ -174,16 +122,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ needs.bump-version.outputs.tag }}" \
-            --title "Release ${{ needs.bump-version.outputs.version }}" \
+          gh release create "${{ steps.version.outputs.tag }}" \
+            --title "Release ${{ steps.version.outputs.version }}" \
             --notes-file release-notes.md \
             dist/*
 
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [bump-version, create-release]
-    if: ${{ !inputs.dry_run }}
+    needs: create-release
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
     environment:
       name: pypi
       url: https://pypi.org/project/sqlrepository/
@@ -205,17 +153,18 @@ jobs:
   dry-run-summary:
     name: Dry Run Summary
     runs-on: ubuntu-latest
-    needs: [bump-version, build]
-    if: ${{ inputs.dry_run }}
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && inputs.dry_run
     steps:
       - name: Summary
         run: |
           echo "Dry run completed successfully!"
           echo ""
-          echo "Would have released: ${{ needs.bump-version.outputs.version }}"
-          echo "Bump type: ${{ inputs.bump_type }}"
+          echo "Checks passed and package built. Skipped: GitHub release and PyPI publish."
           echo ""
-          echo "Checks passed, package built."
-          echo "Skipped: version commit, git tag, GitHub release, PyPI publish."
-          echo ""
-          echo "To release for real, run this workflow without dry-run mode."
+          echo "To release for real, push a version tag:"
+          echo "  uv version --bump patch|minor|major"
+          echo "  git add pyproject.toml uv.lock"
+          echo "  git commit -m 'chore: bump version to X.Y.Z'"
+          echo "  git tag vX.Y.Z"
+          echo "  git push origin main vX.Y.Z"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,13 @@ sqlrepository/
 │   ├── copilot-skills/
 │   │   ├── chore.instructions.md
 │   │   └── release.instructions.md
+│   ├── actions/
+│   │   └── setup-env/action.yml     # Composite action: setup-uv + uv sync
+│   ├── dependabot.yml               # Automated github-actions version updates
 │   └── workflows/
 │       ├── ci.yml                   # Quality checks + tests on push/PR
-│       ├── release.yml              # Manual release to PyPI
-│       └── build-wheels.yml
+│       ├── release.yml              # Release on vX.Y.Z tag push
+│       └── update-deps.yml          # Weekly uv lock --upgrade PR
 ├── src/sqlrepository/
 │   ├── __init__.py                  # Exports: Repository, AsyncRepository, EntityType, IdType
 │   ├── core.py                      # Sync repository (SQLAlchemy DeclarativeBase)
@@ -248,12 +251,13 @@ sqlalchemy >= 2.0.46, < 3.0.0
 
 ### Dev Group
 
-Includes everything: pytest, pytest-asyncio, pytest-coverage, ruff, pyright, sqlmodel, aiosqlite, greenlet.
+Includes everything: pytest, pytest-asyncio, pytest-cov, ruff, pyright, sqlmodel, aiosqlite, greenlet, twine, git-cliff.
 
 ### Constraint Notes
 
 - **pytest < 9** is required because `pytest-asyncio 0.26.x` does not support pytest 9 yet.
 - `aiosqlite` is a dev-only dependency (async SQLite driver used in tests).
+- Use `pytest-cov` (not `pytest-coverage` — different package) for the `--cov` flags.
 
 ---
 
@@ -263,19 +267,36 @@ Includes everything: pytest, pytest-asyncio, pytest-coverage, ruff, pyright, sql
 
 | Workflow | Trigger | Steps |
 |----------|---------|-------|
-| `ci.yml` | Push / PR to `main` | ruff lint → ruff format check → pyright → Trivy scan → pytest (Python 3.11–3.14) → Codecov upload |
-| `release.yml` | Manual `workflow_dispatch` | Quality gate → build wheel+sdist → create git tag → GitHub release → publish to PyPI |
-| `build-wheels.yml` | Legacy | Wheel building |
+| `ci.yml` | Push / PR to `main` | ruff lint → ruff format check → pyright → Trivy scan (SARIF) → pytest (Python 3.11–3.14) → Codecov upload |
+| `release.yml` | Push of `v*` tag | Quality gate → build wheel+sdist → twine check → GitHub release (git-cliff notes) → publish to PyPI |
+| `update-deps.yml` | Weekly (Monday 06:00 UTC) | `uv lock --upgrade` → open PR if lock file changed |
 
 ### Release Process
 
-1. Update `version` in `pyproject.toml` (semantic versioning: `MAJOR.MINOR.PATCH`)
-2. Commit: `git commit -m "chore: bump version to X.Y.Z"`
-3. Push to `main`
-4. Go to GitHub Actions → "Release" workflow → "Run workflow"
-5. The workflow handles tagging, GitHub release creation, and PyPI publishing via trusted publishing.
+1. Bump version using uv:
+   ```bash
+   uv version --bump patch   # or minor, major
+   ```
+2. Commit and tag:
+   ```bash
+   git add pyproject.toml uv.lock
+   git commit -m "chore: bump version to X.Y.Z"
+   git tag vX.Y.Z
+   git push origin main vX.Y.Z
+   ```
+3. The `release.yml` workflow triggers automatically on the tag push and handles the GitHub release and PyPI publishing.
+
+> **Dry run**: Trigger `release.yml` manually via `workflow_dispatch` with `dry_run: true` to verify quality gate and build without publishing.
 
 See `.github/CICD.md` for full details.
+
+### Security
+
+- All third-party GitHub Actions are pinned to commit SHAs (with version comments).
+- Trivy scans for CRITICAL/HIGH vulnerabilities and uploads results to the GitHub Security tab as SARIF.
+- Dependabot keeps GitHub Actions SHA pins current (weekly).
+- `update-deps.yml` keeps Python dependencies current via weekly `uv lock --upgrade` PRs.
+- Coverage must meet an 80% threshold (`--cov-fail-under=80`) or CI fails.
 
 ### Commit Prefixes (Conventional Commits)
 

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ uv run ruff check --fix src tests
 uv run ruff format src tests
 
 # Type checking
-uv run mypy src/sqlrepository --ignore-missing-imports
+uv run pyright src
 ```
 
 ### Submitting Changes
@@ -551,22 +551,24 @@ uv run mypy src/sqlrepository --ignore-missing-imports
 - Ensure CI checks pass before requesting review
 
 All pull requests trigger automated checks:
-- ✅ Linting (ruff)
-- ✅ Type checking (mypy)
-- ✅ Security scanning (pip-audit)
-- ✅ Tests on Python 3.11 & 3.12
-- ✅ Coverage reporting
+- ✅ Linting and formatting (ruff)
+- ✅ Type checking (pyright)
+- ✅ Security scanning (Trivy — results in GitHub Security tab)
+- ✅ Tests on Python 3.11, 3.12, 3.13, and 3.14
+- ✅ Coverage reporting (80% minimum threshold)
 
 ### Release Process
 
-Releases are fully automated via GitHub Actions. See [CI/CD Documentation](.github/CICD.md) for details.
+Releases are triggered by pushing a version tag. The workflow handles the GitHub release and PyPI publishing automatically.
 
 **Quick release steps**:
-1. Update version in `pyproject.toml`
-2. Commit: `git commit -m "chore: bump version to X.Y.Z"`
-3. Push to GitHub
-4. Go to Actions → Release workflow → Run workflow
-5. Package is automatically built, tagged, and published to PyPI
+```bash
+uv version --bump patch   # or minor, major
+git add pyproject.toml uv.lock
+git commit -m "chore: bump version to X.Y.Z"
+git tag vX.Y.Z
+git push origin main vX.Y.Z
+```
 
 For detailed instructions, see [`.github/CICD.md`](.github/CICD.md).
 


### PR DESCRIPTION
## Summary

- **Security**: All third-party actions SHA-pinned; `permissions: contents: read` at workflow level; Trivy SARIF uploaded to GitHub Security tab; Dependabot for GitHub Actions ecosystem
- **Correctness**: Delete `build-wheels.yml` (was firing on every release causing duplicate uploads); replace `pytest-coverage` with `pytest-cov`; add Python 3.13/3.14 classifiers; fix codecov `file` → `files` (v5 breaking change); correct hallucinated SHA for `peter-evans/create-pull-request`
- **Reliability**: uv dependency caching in CI; `--cov-fail-under=80`; `twine check` before PyPI publish; `fail-fast: false` on test matrix; `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` for Node.js 20 deprecation
- **Release process**: Switched from `workflow_dispatch` with auto-bump to tag-based trigger (`v*`) — removes the need for the bot to push directly to `main`, compatible with branch protection
- **Maintainability**: Composite action for shared `setup-uv + uv sync`; `git-cliff` for structured release notes; `gh release create` replaces `softprops/action-gh-release`; weekly `uv lock --upgrade` PR workflow; updated CLAUDE.md and README.md

## Test plan

- [ ] CI workflow passes (quality + test matrix on 3.11–3.14)
- [ ] Trivy SARIF results appear in the Security tab
- [ ] Coverage meets the 80% threshold
- [ ] "Update dependencies" workflow runs without errors
- [ ] `uv sync --all-groups` resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)