### PR TITLE
fix: opt into Node.js 24 in update-deps workflow

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true  # Remove once tibdex/github-app-token ships Node.js 24 support
+
 jobs:
   update:
     name: uv lock --upgrade


### PR DESCRIPTION
## Summary

Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to `update-deps.yml` to silence the Node.js 20 deprecation warning from `tibdex/github-app-token@v2.1.0`, which has no Node.js 24 release yet.

Same pattern already applied to `ci.yml`. Comment marks it for removal once Dependabot bumps `tibdex/github-app-token` to a version with Node.js 24 support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)