### PR TITLE
fix: use uv run git-cliff in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Generate release notes
         run: |
-          git cliff --latest --output release-notes.md
+          uv run git-cliff --latest --output release-notes.md
           cat release-notes.md
 
       - name: Create GitHub Release


### PR DESCRIPTION
`git cliff` only works as a git subcommand when `git-cliff` is on PATH. Installed via `uv` it lives in the virtualenv, so it must be invoked as `uv run git-cliff`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)