### PR TITLE
feat: switch to hatch-vcs dynamic versioning

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -99,19 +99,16 @@ Runs instead of `create-release` and `publish-pypi` when triggered via `workflow
 
 ### Triggering a Release
 
-Bump the version locally, then push a tag:
+Push a tag from any commit on `main`:
 
 ```bash
-uv version --bump patch   # or: minor, major
-git add pyproject.toml uv.lock
-git commit -m "chore: bump version to X.Y.Z"
 git tag vX.Y.Z
-git push origin main vX.Y.Z
+git push origin vX.Y.Z
 ```
 
-The workflow will automatically:
+The version is derived from the tag by `hatch-vcs` at build time — there is no version stored in `pyproject.toml`. The workflow will automatically:
 - Run all quality checks on the tagged commit
-- Build and validate the package
+- Build and validate the package (version resolved from the tag)
 - Generate release notes from conventional commits via `git-cliff`
 - Create the GitHub release with the built artifacts attached
 - Publish to PyPI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 A Python repository pattern implementation for SQLAlchemy and SQLModel, inspired by Spring Data JPA repositories. Provides type-safe, zero-boilerplate CRUD operations with sync and async support.
 
-**Current version**: 0.2.0
+**Current version**: derived from git tags (see `git describe --tags`)
 **License**: GPL-3.0
 **Python**: >= 3.11
 

--- a/README.md
+++ b/README.md
@@ -298,17 +298,14 @@ uv run pyright src                # type check
 
 ### Release Process
 
-Bump the version locally, then push a tag — the release workflow triggers automatically:
+Push a tag — the release workflow triggers automatically:
 
 ```bash
-uv version --bump patch   # or: minor, major
-git add pyproject.toml uv.lock
-git commit -m "chore: bump version to X.Y.Z"
 git tag vX.Y.Z
-git push origin main vX.Y.Z
+git push origin vX.Y.Z
 ```
 
-The workflow runs the quality gate, builds the package, publishes a GitHub release with generated release notes, and uploads to PyPI — all without further intervention.
+The version is derived from the tag at build time (no version stored in `pyproject.toml`). The workflow runs the quality gate, builds the package, publishes a GitHub release with generated release notes, and uploads to PyPI — all without further intervention.
 
 > **Dry run**: trigger `release.yml` manually via `workflow_dispatch` with `dry_run: true` to validate the quality gate and build without publishing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "sqlrepository"
-version = "0.2.1"
+dynamic = ["version"]
 description = "A Python repository pattern implementation for SQLAlchemy and SQLModel, inspired by Spring Data JPA repositories."
 
 authors = [
@@ -59,6 +59,9 @@ dev = [
     "aiosqlite>=0.20.0,<0.21.0",
     "greenlet>=3.2.0,<4.0.0",
 ]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/sqlrepository"]

--- a/uv.lock
+++ b/uv.lock
@@ -957,7 +957,6 @@ wheels = [
 
 [[package]]
 name = "sqlrepository"
-version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "sqlalchemy" },
@@ -997,7 +996,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.46,<3.0.0" },
     { name = "sqlmodel", marker = "extra == 'sqlmodel'", specifier = ">=0.0.34,<0.1.0" },
 ]
-provides-extras = ["sqlmodel", "async"]
+provides-extras = ["async", "sqlmodel"]
 
 [package.metadata.requires-dev]
 async = [{ name = "greenlet", specifier = ">=3.2.0,<4.0.0" }]


### PR DESCRIPTION
## Summary

Replaces the static `version` field in `pyproject.toml` with `hatch-vcs` dynamic versioning. The version is now derived from the git tag at build time — no version file to edit, no commit to main, no branch needed.

**New release process:**
```bash
git tag vX.Y.Z
git push origin vX.Y.Z
```
That's it. The existing tag-triggered `release.yml` workflow handles everything else.

## Changes

- `pyproject.toml`: add `hatch-vcs` to `[build-system].requires`, replace `version = "X.Y.Z"` with `dynamic = ["version"]`, add `[tool.hatch.version] source = "vcs"`
- `uv.lock`: updated
- `README.md`, `CICD.md`, `CLAUDE.md`: release process docs simplified to reflect tag-only workflow

## Verified

`uv build` on an untagged commit produces a dev version (`0.2.2.dev1+gc74c2b1e2`); on a `vX.Y.Z` tag it will produce exactly `X.Y.Z`.

> **Note**: this PR is based on `docs/readme-overhaul` — merge that first, then this one will target `main` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)