### PR TITLE
feat: switch to hatch-vcs dynamic versioning

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -99,19 +99,16 @@ Runs instead of `create-release` and `publish-pypi` when triggered via `workflow
 
 ### Triggering a Release
 
-Bump the version locally, then push a tag:
+Push a tag from any commit on `main`:
 
 ```bash
-uv version --bump patch   # or: minor, major
-git add pyproject.toml uv.lock
-git commit -m "chore: bump version to X.Y.Z"
 git tag vX.Y.Z
-git push origin main vX.Y.Z
+git push origin vX.Y.Z
 ```
 
-The workflow will automatically:
+The version is derived from the tag by `hatch-vcs` at build time — there is no version stored in `pyproject.toml`. The workflow will automatically:
 - Run all quality checks on the tagged commit
-- Build and validate the package
+- Build and validate the package (version resolved from the tag)
 - Generate release notes from conventional commits via `git-cliff`
 - Create the GitHub release with the built artifacts attached
 - Publish to PyPI

--- a/.github/instructions.md
+++ b/.github/instructions.md
@@ -377,35 +377,19 @@ sqlrepository/
 
 ### Creating a Release
 
-**The project now uses automated CI/CD for releases!**
+The version is derived from the git tag at build time (`hatch-vcs`) — no version file to edit.
 
-1. **Update version**: Edit `pyproject.toml` (semantic versioning)
-   ```toml
-   [project]
-   version = "0.2.0"  # Update this
-   ```
-
-2. **Commit and push**:
+1. **Push a tag** from any commit on `main`:
    ```bash
-   git add pyproject.toml
-   git commit -m "chore: bump version to 0.2.0"
-   git push
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
    ```
 
-3. **Trigger release workflow**:
-   - Go to GitHub Actions tab
-   - Select "Release" workflow
-   - Click "Run workflow"
-   - Choose branch (usually `main`)
-   - Click "Run workflow"
-
-4. **Automated steps** (no manual intervention):
-   - ✅ Extract version from pyproject.toml
-   - ✅ Run quality checks (lint, format, mypy, tests)
-   - ✅ Build package (wheel + sdist)
-   - ✅ Create git tag (e.g., `v0.2.0`)
-   - ✅ Create GitHub release with notes
-   - ✅ Publish to PyPI
+2. **Automated steps** (no manual intervention):
+   - ✅ Quality gate (lint, format, pyright, tests)
+   - ✅ Build package (wheel + sdist, version from tag)
+   - ✅ Create GitHub release with git-cliff release notes
+   - ✅ Publish to PyPI via trusted publishing
 
 See [`.github/CICD.md`](.github/CICD.md) for detailed CI/CD documentation.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,15 @@
 # This workflow automates the release process when a version tag is pushed.
 #
 # Flow:
-#   1. Developer bumps version locally and pushes a vX.Y.Z tag
+#   1. Developer pushes a vX.Y.Z tag — no version commit needed
 #   2. Quality gate runs on the tagged commit
-#   3. Build wheel + sdist
+#   3. Build wheel + sdist (version derived from tag via hatch-vcs)
 #   4. Create GitHub release with git-cliff release notes
 #   5. Publish to PyPI via trusted publishing
 #
 # Release steps:
-#   uv version --bump patch|minor|major
-#   git add pyproject.toml uv.lock
-#   git commit -m "chore: bump version to X.Y.Z"
 #   git tag vX.Y.Z
-#   git push origin main vX.Y.Z
+#   git push origin vX.Y.Z
 
 name: Release
 
@@ -163,8 +160,5 @@ jobs:
           echo "Checks passed and package built. Skipped: GitHub release and PyPI publish."
           echo ""
           echo "To release for real, push a version tag:"
-          echo "  uv version --bump patch|minor|major"
-          echo "  git add pyproject.toml uv.lock"
-          echo "  git commit -m 'chore: bump version to X.Y.Z'"
           echo "  git tag vX.Y.Z"
-          echo "  git push origin main vX.Y.Z"
+          echo "  git push origin vX.Y.Z"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 A Python repository pattern implementation for SQLAlchemy and SQLModel, inspired by Spring Data JPA repositories. Provides type-safe, zero-boilerplate CRUD operations with sync and async support.
 
-**Current version**: 0.2.0
+**Current version**: derived from git tags (see `git describe --tags`)
 **License**: GPL-3.0
 **Python**: >= 3.11
 
@@ -273,18 +273,14 @@ Includes everything: pytest, pytest-asyncio, pytest-cov, ruff, pyright, sqlmodel
 
 ### Release Process
 
-1. Bump version using uv:
-   ```bash
-   uv version --bump patch   # or minor, major
-   ```
-2. Commit and tag:
-   ```bash
-   git add pyproject.toml uv.lock
-   git commit -m "chore: bump version to X.Y.Z"
-   git tag vX.Y.Z
-   git push origin main vX.Y.Z
-   ```
-3. The `release.yml` workflow triggers automatically on the tag push and handles the GitHub release and PyPI publishing.
+The version is derived from the git tag at build time (`hatch-vcs`) — no version file to edit. Push a tag and the workflow handles the rest:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The `release.yml` workflow triggers automatically on the tag push and handles the GitHub release and PyPI publishing.
 
 > **Dry run**: Trigger `release.yml` manually via `workflow_dispatch` with `dry_run: true` to verify quality gate and build without publishing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "sqlrepository"
-version = "0.2.1"
+dynamic = ["version"]
 description = "A Python repository pattern implementation for SQLAlchemy and SQLModel, inspired by Spring Data JPA repositories."
 
 authors = [
@@ -59,6 +59,9 @@ dev = [
     "aiosqlite>=0.20.0,<0.21.0",
     "greenlet>=3.2.0,<4.0.0",
 ]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/sqlrepository"]

--- a/uv.lock
+++ b/uv.lock
@@ -957,7 +957,6 @@ wheels = [
 
 [[package]]
 name = "sqlrepository"
-version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "sqlalchemy" },
@@ -997,7 +996,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.46,<3.0.0" },
     { name = "sqlmodel", marker = "extra == 'sqlmodel'", specifier = ">=0.0.34,<0.1.0" },
 ]
-provides-extras = ["sqlmodel", "async"]
+provides-extras = ["async", "sqlmodel"]
 
 [package.metadata.requires-dev]
 async = [{ name = "greenlet", specifier = ">=3.2.0,<4.0.0" }]


### PR DESCRIPTION
## Summary

Two things in one commit:

**1. Switch to hatch-vcs dynamic versioning**

Replaces the static `version` field in `pyproject.toml` with `hatch-vcs` so the version is derived from the git tag at build time. No version file to edit, no commit to main, no branch needed.

New release process:
```bash
git tag vX.Y.Z
git push origin vX.Y.Z
```

**2. Fix stale release instructions across all docs**

Several files still referenced the old `uv version --bump` + commit + tag process. All updated to reflect the tag-only flow:
- `release.yml` header comment and dry-run summary echo
- `CLAUDE.md` version header and release process section
- `.github/CICD.md` "Triggering a Release" section
- `.github/instructions.md` "Creating a Release" section

## Changes

- `pyproject.toml`: add `hatch-vcs` to `[build-system].requires`, replace `version = "X.Y.Z"` with `dynamic = ["version"]`, add `[tool.hatch.version] source = "vcs"`
- `uv.lock`: updated
- `release.yml`, `CLAUDE.md`, `CICD.md`, `instructions.md`: stale docs fixed

## Verified

`uv build` on an untagged commit produces `0.2.2.dev1+g6cabbf038` — on a `vX.Y.Z` tag it will produce exactly `X.Y.Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)